### PR TITLE
Make it working on Ubuntu

### DIFF
--- a/pci_lib/pci_lib.py
+++ b/pci_lib/pci_lib.py
@@ -695,7 +695,21 @@ def shorten_pci_addr(pci_addr):
 
 def load_pci_ids():
     db = {}
-    with open('/usr/share/hwdata/pci.ids') as f:
+    pci_ids_locations = [
+        "/usr/share/hwdata/pci.ids",
+        "/usr/share/misc/pci.ids",
+    ]
+    pci_ids_location = None
+    for loc in pci_ids_locations:
+        if os.path.isfile(loc):
+            pci_ids_location = loc
+            break
+    if not pci_ids_location:
+        raise RuntimeError(
+            "No pci.ids file avail in %r" % pci_ids_locations
+        )
+
+    with open(pci_ids_location) as f:
         vid = None
         did = None
         for line in f:


### PR DESCRIPTION
It fails on Ubuntu, because the pci.ids file location differ. On CentOS it's /usr/share/hwdata/pci.ids while on Ubuntu it's /usr/share/misc/pci.ids. Try CentOS location first, if it's not there fail to the Ubuntu one. If the file is not available in either of the locations, fail with clear error.

Test plan:
The file is not available, it fails:
```
/tmp/pcicrawler_1# ls -l /usr/share/hwdata/pci.ids /usr/share/misc/pci.ids
ls: cannot access '/usr/share/hwdata/pci.ids': No such file or directory
ls: cannot access '/usr/share/misc/pci.ids': No such file or directory
/tmp/pcicrawler_1# pcicrawler -t
00:01.1 root_port, slot 0, device present, speed 8GT/s, width x4
Traceback (most recent call last):
  File "/usr/local/bin/pcicrawler", line 11, in <module>
    load_entry_point('pcicrawler==0.1.0', 'console_scripts', 'pcicrawler')()
  File "/usr/lib/python3/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pcicrawler/cli.py", line 233, in main
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pcicrawler/cli.py", line 139, in print_tree
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pcicrawler/cli.py", line 121, in print_tree_level
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pcicrawler/cli.py", line 118, in print_tree_level
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pci_lib/pci_lib.py", line 43, in __get__
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pci_lib/pci_lib.py", line 377, in name
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pci_lib/pci_lib.py", line 768, in lookup_device
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pci_lib/pci_lib.py", line 761, in get_pci_db
  File "/usr/local/lib/python3.6/dist-packages/pcicrawler-0.1.0-py3.6.egg/pci_lib/pci_lib.py", line 709, in load_pci_ids
RuntimeError: No pci.ids file avail in ['/usr/share/hwdata/pci.ids', '/usr/share/misc/pci.ids']
/tmp/pcicrawler_1#

```
The file is available in CentOS location:
```
/tmp/pcicrawler_1# ls -l /usr/share/hwdata/pci.ids /usr/share/misc/pci.ids
ls: cannot access '/usr/share/misc/pci.ids': No such file or directory
-rw-r--r-- 1 root root 1126913 Feb 10  2019 /usr/share/hwdata/pci.ids
/tmp/pcicrawler_1#

/tmp/pcicrawler_1# pcicrawler -t
00:01.1 root_port, slot 0, device present, speed 8GT/s, width x4
....
```

The file is available in Ubuntu location:
```
/tmp/pcicrawler_1# ls -l /usr/share/hwdata/pci.ids /usr/share/misc/pci.ids
ls: cannot access '/usr/share/hwdata/pci.ids': No such file or directory
-rw-r--r-- 1 root root 1126913 Feb 10  2019 /usr/share/misc/pci.ids
/tmp/pcicrawler_1#

/tmp/pcicrawler_1# pcicrawler -t
00:01.1 root_port, slot 0, device present, speed 8GT/s, width x4
...
```