### PR TITLE
Initial PCIe Advanced Error Reporting (AER) support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Options:
                                   workwith --tree
   -x, --hexify / --no-hexify      Output vendor/device/class IDs as hex
                                   strings instead of numbers in JSON output
+  -a, --aer / --no-aer            Include PCIe Advanced Error Reporting (AER)
+                                  information when available - only provided
+                                  in JSON output
   --help                          Show this message and exit.
 ```
 

--- a/pcicrawler/cli.py
+++ b/pcicrawler/cli.py
@@ -24,7 +24,7 @@ import os
 import sys
 
 
-def jsonify(dev, hexify=False, vpd=False):
+def jsonify(dev, hexify=False, vpd=False, aer=False):
     jd = dev._asdict()
     exptype = dev.express_type
     explink = dev.express_link
@@ -53,6 +53,10 @@ def jsonify(dev, hexify=False, vpd=False):
     if vpd:
         if dev.vpd:
             jd['vpd'] = dev.vpd
+    if aer:
+        aer_info = dev.express_aer
+        if aer_info:
+            jd['aer'] = aer_info
     return jd
 
 
@@ -172,8 +176,11 @@ def no_scripting():
 @click.option('--hexify/--no-hexify', '-x', default=False,
               help='Output vendor/device/class IDs as hex '
                    'strings instead of numbers in JSON output')
+@click.option('--aer/--no-aer', '-a', default=False,
+              help='Include PCIe Advanced Error Reporting (AER) information '
+              'when available - only provided in JSON output')
 def main(class_id, device, express_only, json, include_path, addr, tree,
-            verbose, vpd, hexify):
+            verbose, vpd, hexify, aer):
     """
     Tool to display/filter/export information about PCI or PCI Express devices,
     as well as their topology.
@@ -234,7 +241,7 @@ def main(class_id, device, express_only, json, include_path, addr, tree,
         jdevs = {}
         for dev in devs:
             addr = dev.device_name
-            jdevs[addr] = jsonify(dev, hexify=hexify, vpd=vpd)
+            jdevs[addr] = jsonify(dev, hexify=hexify, vpd=vpd, aer=aer)
         click.echo(dumps(jdevs))
     else:
         no_scripting()


### PR DESCRIPTION
* AER information is only included in the JSON output.
* AER output is not included by default, use the -a or --aer optional
  command line parameter to include the AER details.
* AER information is only provided for devices that support the PCIe
  AER capability and the Linux kernel being used must also provide
  support for PCIe AER statistics, supported devices will have various
  aer_* files under /sys/bus/pci/devices/<dev>/.

README.md: Updated usage message.
pci_lib/pci_lib.py: Added AER support.
pcicrawler/cli.py: Added AER support including support for command line.