### PR TITLE
add description in EXPRESS_SPEED for gen5 device

### DIFF
--- a/pci_lib/pci_lib.py
+++ b/pci_lib/pci_lib.py
@@ -181,6 +181,7 @@ EXPRESS_SPEED = {
     2: "5GT/s",
     3: "8GT/s",
     4: "16GT/s",
+    5: "32GT/s",
 }
 
 


### PR DESCRIPTION
Gen5 NVMe Disk will be published in next year. So add it for display