### PR TITLE
Allow usage as non-root for basic information

### DIFF
--- a/pci_lib/pci_lib.py
+++ b/pci_lib/pci_lib.py
@@ -153,8 +153,11 @@ def find_capability(config, cap):
             )
             return None
         config.been_there[pos] = True
-        pos = read_u8(config, pos)
-        cap_id = read_u8(config, pos)
+        try:
+            pos = read_u8(config, pos)
+            cap_id = read_u8(config, pos)
+        except Exception:
+            continue
         if cap_id == cap:
             return pos
         pos += 1
@@ -620,7 +623,10 @@ class PCIDevice(
 def get_dmidecode_pci_slots():
     slotmap = {}
     try:
-        dmiout = subprocess.check_output(["/sbin/dmidecode", "-t", "slot"])
+        dmiout = subprocess.check_output(
+            ["/sbin/dmidecode", "-t", "slot"],
+            stderr=subprocess.DEVNULL,
+        )
         dmiout = dmiout.decode("utf-8")
         slots = []
         slot = None


### PR DESCRIPTION
I think it would be nice to have non-root access to this utility:

Without root:
![image](https://github.com/opencomputeproject/ocp-diag-pcicrawler/assets/90008/2c842d88-f288-4858-93e1-6e7e3454b7ec)

With root
![image](https://github.com/opencomputeproject/ocp-diag-pcicrawler/assets/90008/3697c545-d46a-4766-8d56-10b4b6361f32)

While the information about the speed isn't there, in the `--tree` usecase (which I use on system bringup) this is a very useful overview.

If you will consider, I can cleanup.